### PR TITLE
Add ReadWriteWorker protocol and a property wrapper `ThreadSafe`

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcbaselines/DevKitTests.xcbaseline/BE1368E3-E27A-47FD-9905-866A0B5F8E87.plist
+++ b/.swiftpm/xcode/xcshareddata/xcbaselines/DevKitTests.xcbaseline/BE1368E3-E27A-47FD-9905-866A0B5F8E87.plist
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>ThreadSafeWorkerMeasureTests</key>
+		<dict>
+			<key>testMeasureGCDBarrier()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.24</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testMeasureNSLock()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0791</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testMeasurePOSIX()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0655</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/.swiftpm/xcode/xcshareddata/xcbaselines/DevKitTests.xcbaseline/Info.plist
+++ b/.swiftpm/xcode/xcshareddata/xcbaselines/DevKitTests.xcbaseline/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>runDestinationsByUUID</key>
+	<dict>
+		<key>BE1368E3-E27A-47FD-9905-866A0B5F8E87</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>400</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>6-Core Intel Core i7</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>2600</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>12</integer>
+				<key>modelCode</key>
+				<string>MacBookPro16,1</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>6</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>x86_64</string>
+			<key>targetDevice</key>
+			<dict>
+				<key>modelCode</key>
+				<string>iPhone13,3</string>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.iphonesimulator</string>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Sources/DevKit/Concurrency/GCDBarrierWorker.swift
+++ b/Sources/DevKit/Concurrency/GCDBarrierWorker.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public struct GCDBarrierWorker {
+    let queue: DispatchQueue
+
+    public init(qos: DispatchQoS = .default) {
+        let typeName = String(describing: GCDBarrierWorker.self)
+        let uuidPrefix = UUID().uuidString.prefix(6)
+        let identifier = "queue.\(typeName)-\(uuidPrefix)"
+        self.queue = DispatchQueue(label: identifier, qos: qos, attributes: .concurrent)
+    }
+}
+
+extension GCDBarrierWorker: ReadWriteWorker {
+    public func safeRead<T>(_ block: @escaping () -> T) -> T {
+        queue.sync {
+            let value = block()
+            return value
+        }
+    }
+
+    public func safeWrite(_ block: @escaping () -> Void) {
+        let workItem = DispatchWorkItem(flags: .barrier, block: block)
+        queue.sync(execute: workItem)
+    }
+}

--- a/Sources/DevKit/Concurrency/NSLockWorker.swift
+++ b/Sources/DevKit/Concurrency/NSLockWorker.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+public struct NSLockWorker {
+    let lock: NSLock
+
+    public init() {
+        self.lock = NSLock()
+    }
+}
+
+extension NSLockWorker: ReadWriteWorker {
+    public func safeRead<T>(_ block: @escaping () -> T) -> T {
+        lock.lock()
+        let value = block()
+        lock.unlock()
+        return value
+    }
+
+    public func safeWrite(_ block: @escaping () -> Void) {
+        lock.lock()
+        block()
+        lock.unlock()
+    }
+}

--- a/Sources/DevKit/Concurrency/POSIXWorker.swift
+++ b/Sources/DevKit/Concurrency/POSIXWorker.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+public final class POSIXWorker {
+    var lock = pthread_rwlock_t()
+
+    public init() {
+        pthread_rwlock_init(&lock, nil)
+    }
+
+    deinit {
+        pthread_rwlock_destroy(&lock)
+    }
+}
+
+extension POSIXWorker: ReadWriteWorker {
+    public func safeRead<T>(_ block: @escaping () -> T) -> T {
+        pthread_rwlock_rdlock(&lock)
+        let value = block()
+        pthread_rwlock_unlock(&lock)
+        return value
+    }
+
+    public func safeWrite(_ block: @escaping () -> Void) {
+        pthread_rwlock_wrlock(&lock)
+        block()
+        pthread_rwlock_unlock(&lock)
+    }
+}

--- a/Sources/DevKit/Concurrency/ReadWriteWorker.swift
+++ b/Sources/DevKit/Concurrency/ReadWriteWorker.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public protocol ReadWriteWorker {
+    func safeRead<T>(_ block: @escaping () -> T) -> T
+    func safeWrite(_ block: @escaping () -> Void)
+}

--- a/Sources/DevKit/PropertyWrapper/ThreadSafe.swift
+++ b/Sources/DevKit/PropertyWrapper/ThreadSafe.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+@propertyWrapper
+public final class ThreadSafe<Value> {
+    public var wrappedValue: Value {
+        get {
+            safeRead()
+        }
+        set {
+            safeWrite(newValue)
+        }
+    }
+
+    public var projectedValue: ThreadSafe<Value> {
+        return self
+    }
+
+    private let worker: ReadWriteWorker
+    private var value: Value
+
+    public init<Worker: ReadWriteWorker>(wrappedValue: Value, worker: Worker) {
+        self.value = wrappedValue
+        self.worker = worker
+    }
+
+    public func safeRead() -> Value {
+        worker.safeRead { [unowned self] in
+            self.value
+        }
+    }
+
+    public func safeWrite(_ value: Value) {
+        worker.safeWrite { [unowned self] in
+            self.value = value
+        }
+    }
+
+    public func safeWrite(_ updates: @escaping (inout Value) -> Void) {
+        worker.safeWrite { [unowned self] in
+            updates(&self.value)
+        }
+    }
+}

--- a/Tests/DevKitTests/Concurrency/ReadWriteWorkerTests.swift
+++ b/Tests/DevKitTests/Concurrency/ReadWriteWorkerTests.swift
@@ -1,0 +1,76 @@
+import DevKit
+import XCTest
+
+final class ReadWriteWorkerTests: XCTestCase {
+    func testGCDBarrier() {
+        let worker = GCDBarrierWorker()
+        assertNoRaceCondition(for: worker)
+        XCTAssertEqual(worker.safeRead { return 1 }, 1)
+    }
+
+    func testNSLock() {
+        let worker = NSLockWorker()
+        assertNoRaceCondition(for: worker)
+        XCTAssertEqual(worker.safeRead { return 1 }, 1)
+    }
+
+    func testPOSIX() {
+        let worker = POSIXWorker()
+        assertNoRaceCondition(for: worker)
+        XCTAssertEqual(worker.safeRead { return 1 }, 1)
+    }
+
+    private func assertNoRaceCondition<Worker: ReadWriteWorker>(for worker: Worker) {
+        let taskCount = 50000
+
+        var counter = 0
+
+        for i in 0 ..< taskCount {
+            let promise = expectation(description: i.description)
+
+            DispatchQueue.global().async {
+                worker.safeWrite {
+                    counter += 1
+                }
+                promise.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: 10) { _ in
+            XCTAssertEqual(counter, taskCount)
+        }
+    }
+}
+
+final class ThreadSafeWorkerMeasureTests: XCTestCase {
+    func testMeasureGCDBarrier() {
+        let worker = GCDBarrierWorker()
+        measure {
+            executionTime(for: worker)
+        }
+    }
+
+    func testMeasureNSLock() {
+        let worker = NSLockWorker()
+        measure {
+            executionTime(for: worker)
+        }
+    }
+
+    func testMeasurePOSIX() {
+        let worker = POSIXWorker()
+        measure {
+            executionTime(for: worker)
+        }
+    }
+
+    private func executionTime<Worker: ReadWriteWorker>(for worker: Worker) {
+        let taskCount = 200000
+        var counter = 0
+        for _ in 0 ..< taskCount {
+            worker.safeWrite {
+                counter += 1
+            }
+        }
+    }
+}

--- a/Tests/DevKitTests/PropertyWrapper/ThreadSafeTests.swift
+++ b/Tests/DevKitTests/PropertyWrapper/ThreadSafeTests.swift
@@ -1,0 +1,62 @@
+import DevKit
+import XCTest
+
+final class ThreadSafeArrayTests: XCTestCase {
+    @ThreadSafe(worker: POSIXWorker())
+    var array: [Int] = [1, 4, 2, 3, 5]
+
+    func testReadAndWrite() {
+        array[4] = 6
+        XCTAssertEqual(array[1], 4)
+        XCTAssertEqual(array, [1, 4, 2, 3, 6])
+    }
+
+    func testAppend() {
+        array.append(6)
+        XCTAssertEqual(array, [1, 4, 2, 3, 5, 6])
+    }
+
+    func testRemoveAll() {
+        array.removeAll()
+        XCTAssertEqual(array, [])
+    }
+}
+
+final class ThreadSafeDictionaryTests: XCTestCase {
+    @ThreadSafe(worker: POSIXWorker())
+    var cache: [String: String] = [:]
+
+    func testUpdateValue() {
+        cache["foo"] = "bar"
+        cache["hello"] = "world"
+        XCTAssertEqual(cache, ["foo": "bar", "hello": "world"])
+    }
+
+    func testOverwriteValue() {
+        let dict = ["yeah": "yo", "whoo": "ha"]
+        cache = ["yeah": "yo", "whoo": "ha"]
+        XCTAssertEqual(cache, dict)
+    }
+}
+
+final class ThreadSafeObjectTests: XCTestCase {
+    class Pet {
+        var name: String
+        var grams: Double
+
+        init(name: String, grams: Double) {
+            self.name = name
+            self.grams = grams
+        }
+    }
+
+    @ThreadSafe(worker: POSIXWorker())
+    var hamster = Pet(name: "gueji", grams: 31.5)
+
+    func testUpdateValueClosure() {
+        $hamster.safeWrite { pet in
+            pet.grams = 45
+        }
+        XCTAssertEqual(hamster.grams, 45)
+    }
+}


### PR DESCRIPTION
- Add an interface `ReadWriterWorker` that facilitate thread-safe read/write functions
- Add a property wrapper `ThreadSafe` to wrap variables into a thread-safe context